### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/libs/email/templates/index.ts
+++ b/libs/email/templates/index.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import config from '@/config';
+import striptags from 'striptags';
 
 export interface EmailTemplate {
   subject: string;
@@ -122,8 +123,7 @@ export async function loadEmailTemplate(
     text = fs.readFileSync(textPath, 'utf8');
   } catch {
     // If text template doesn't exist, generate from HTML
-    text = html
-      .replaceAll(/<[^>]*>/g, '')
+    text = striptags(html)
       .replaceAll(/\s+/g, ' ')
       .trim();
   }


### PR DESCRIPTION
Potential fix for [https://github.com/ShareSkippy/RideShareTahoe/security/code-scanning/5](https://github.com/ShareSkippy/RideShareTahoe/security/code-scanning/5)

The best fix is to use a well-tested library to correctly and thoroughly strip all HTML tags from the input, eliminating the risks of incomplete multi-character sanitization and covering edge cases that regex alone cannot handle. For Node.js projects, `striptags` is a widely used package that securely removes all HTML tags and leaves plain text, which is suitable for generating plaintext sections of emails. This fix only requires changing the code block at line 125–128 to use the library, and adding the necessary import at the top of the file. If external dependencies are not an option, a fallback would be a loop applying the regex until the string stabilizes, but this is less robust.

Specifically:
1. Add an import for `striptags` at the top of `libs/email/templates/index.ts`.
2. In the catch block where the text fallback is generated from HTML, replace `.replaceAll(/<[^>]*>/g, '')` with `striptags(html)`.
3. Remove the next line that collapses whitespaces, as `striptags` already returns plain text; if further normalization is desired, retain `.replaceAll(/\s+/g, ' ')` and `.trim()`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
