### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/re-engage-users.yml
+++ b/.github/workflows/re-engage-users.yml
@@ -1,4 +1,6 @@
 name: Re-engage Inactive Users
+permissions:
+  contents: read
 
 on:
   # DISABLED: Automated re-engagement emails to prevent spam


### PR DESCRIPTION
Potential fix for [https://github.com/ShareSkippy/RideShareTahoe/security/code-scanning/1](https://github.com/ShareSkippy/RideShareTahoe/security/code-scanning/1)

To address the error, we should add a `permissions` block to the workflow that limits the GITHUB_TOKEN to the minimal necessary privileges. Since none of the workflow steps require write access, a read-only permission is sufficient. The best practice is to set `contents: read` (the minimal permission needed for jobs that only need access to actions). This should be placed at the workflow root (recommended for single-job workflows). No changes are needed to any steps, imports, or variables.

**Specific change:**  
- Add the following block after the workflow name (before `on:`):  
  ```yaml
  permissions:
    contents: read
  ```
- There is only one file (.github/workflows/re-engage-users.yml), and only a single region at the top of the file needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
